### PR TITLE
change help text to macOS from OS X

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -39,7 +39,7 @@ do
         opt_offline=t
       ;;
     -h|--help)
-      echo "Archey OS X 1.7.0"
+      echo "Archey macOS 1.7.0"
       echo
       echo "Usage: $0 [options]"
       echo


### PR DESCRIPTION
Change help text to "macOS" from "OS X"
